### PR TITLE
use `last` instead of `end` for calculating line count

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ impl Span {
     ///
     /// It is at least one, even if the span is empty.
     pub fn line_count(&self) -> usize {
-        self.end.line - self.start.line + 1
+        self.last.line - self.start.line + 1
     }
 
     /// Checks if the span includes the given line.


### PR DESCRIPTION
Using `end` messes up the formatting if the span goes to the end of the line (with `end` at the start of the next line)

Before:
![Screenshot_20191007_003144](https://user-images.githubusercontent.com/1283854/66277110-583bfa00-e889-11e9-8eff-55a426455752.png)

After:
![Screenshot_20191007_003144](https://user-images.githubusercontent.com/1283854/66277114-6853d980-e889-11e9-864b-03dfe26bf27b.png)

Using:

```rust
let input = "white
             space";
let mut formatter = source_span::fmt::Formatter::new();
formatter.add(
    Span::new(
        Position::new(0, 0),
        Position::new(0, 4),
        Position::new(1, 0),
    ),
    Some("Plain Text".to_string()),
    source_span::fmt::Style::Note,
);

let chars = input.chars().map(|char| Ok(char));
println!(
    "{}",
    formatter
        .get(
            chars,
            Span::new(
                Position::new(0, 0),
                Position::new(1, 22),
                Position::new(1, 23),
            ),
        )
        .unwrap()
);
```